### PR TITLE
Have a look at these fixes

### DIFF
--- a/webapp2/__init__.py
+++ b/webapp2/__init__.py
@@ -751,11 +751,11 @@ class Router(object):
             except Exception, e:
                 handler.handle_exception(e, request.app.debug)
         else:
-            if isinstance(handler_spec, RequestHandler):
+            if issubclass(handler_spec, RequestHandler):
                 # Initialize the Handler object (so that derived Handler classes work properly)
-                handler_spec(request, response)
+                handler = handler_spec(request, response)
                 # then call it
-                handler_spec.dispatch()
+                handler.dispatch()
             else:
                 # A function just call it.
                 handler_spec(request, response)


### PR DESCRIPTION
I ran into some difficulty with webapp2 because of the way RequestHandler.**init** worked.  Basically there was no way to have a derived class from RequestHandler due to the call of self.dispatch at the bottom of **init**.

If you called super at the beginning of your derived class **init** then you never executed your code.  If you called it at the end, then self.request and self.response were not set when you tried to do your specific code.

I fixed all this and seeing how initialize was not callable, took a swat at fixing it too.  Now, if you substitue webapp2 for webapp and the derived RequestHandler based object has an self.initialize method, it will be called (just like in webapp?).

Let me know if you see any problems with this.  If you don't please feel free to include it in your code.  I will license it under the same license you choose for the project.

Thanks for the good work BTW.
