### PR TITLE
Allows using webapp-improved as a non-"dirty" git submodule in zc.buildout projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
+*.py[co]
+
+# When this repository is included as a 
+# submodule within a buildout project,
+# buildout will dump a .egg-info directory
+# into this directory causing the submodule
+# to become "dirty", and this shows up
+# as a change to track in the parent repository.
+# Therefore, we ignore *.egg-info at the
+# repository level.
+*.egg-info
 


### PR DESCRIPTION
-   Ignoring *.egg-info
  -------------------
  When this repository is included as a
  submodule within a buildout project,
  buildout will dump a .egg-info directory
  into this directory causing the submodule
  to become "dirty", and this shows up
  as a change to track in the parent repository.
  Therefore, we ignore *.egg-info at the
  repository level.

Signed-off-by: Gora Khargosh gora.khargosh@gmail.com
