### PR TITLE
Don't override Cache-Control header when testing

### DIFF
--- a/webapp2.py
+++ b/webapp2.py
@@ -334,7 +334,9 @@ class Response(webob.Response):
         """Constructs a response with the default settings."""
         super(Response, self).__init__(*args, **kwargs)
         self.out = self
-        self.headers['Cache-Control'] = 'no-cache'
+        
+        if 'Cache-Control' not in self.headers:
+            self.headers['Cache-Control'] = 'no-cache'
 
     def write(self, text):
         """Appends a text to the response body."""


### PR DESCRIPTION
Cache-Control header is overridden when testing. I wasn't sure if this was intentional, so I've set no-cache only if Cache-Control isn't included in the response.
