### PR TITLE
For example the Google Appengine Search API raises exceptions with

### DIFF
--- a/webapp2.py
+++ b/webapp2.py
@@ -1514,7 +1514,7 @@ class WSGIApplication(object):
 
     def _internal_error(self, exception):
         """Last resource error for :meth:`__call__`."""
-        logging.exception(exception)
+        logging.exception(unicode(exception))
         if self.debug:
             raise
 


### PR DESCRIPTION
For example the Google Appengine Search API raises exceptions with
unicode messages.
If logged with a format string as str, you get:
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf8' in position 39: ordinal not in range(128)
